### PR TITLE
Remove the AWS provider block to enable provider inheritance from the user's root module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ module "polaris-aws-cloud-native-exocompute-networking" {
   aws_exocompute_subnet_1_cidr        = "172.21.1.0/24"
   aws_exocompute_subnet_2_cidr        = "172.21.2.0/24"
   aws_exocompute_vpc_cidr             = "172.21.0.0/16"
-  aws_profile                         = var.aws_profile
-  rsc_exocompute_region               = var.exocompute_region
 }
 ```
 
@@ -119,8 +117,6 @@ No modules.
 | <a name="input_aws_exocompute_vpc_endpoint_eks_name"></a> [aws\_exocompute\_vpc\_endpoint\_eks\_name](#input\_aws\_exocompute\_vpc\_endpoint\_eks\_name) | EKS VPC endpoint name for the AWS account hosting Exocompute. | `string` | `"Rubrik Exocompute VPC EKS Endpoint"` | no |
 | <a name="input_aws_exocompute_vpc_endpoint_s3_name"></a> [aws\_exocompute\_vpc\_endpoint\_s3\_name](#input\_aws\_exocompute\_vpc\_endpoint\_s3\_name) | S3 VPC endpoint name for the AWS account hosting Exocompute. | `string` | `"Rubrik Exocompute VPC S3 Endpoint"` | no |
 | <a name="input_aws_exocompute_vpc_name"></a> [aws\_exocompute\_vpc\_name](#input\_aws\_exocompute\_vpc\_name) | VPC name for the AWS account hosting Exocompute. | `string` | `"Rubrik Exocompute VPC"` | no |
-| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile name. | `string` | n/a | yes |
-| <a name="input_rsc_exocompute_region"></a> [rsc\_exocompute\_region](#input\_rsc\_exocompute\_region) | AWS region for the Exocompute cluster. | `string` | n/a | yes |
 | <a name="input_use_availability_zones_a_and_b"></a> [use\_availability\_zones\_a\_and\_b](#input\_use\_availability\_zones\_a\_and\_b) | Setting this variable to `true` forces the use of availability zones `a` and `b` for the subnets in the VPC. The default behavior is to use the first two availability zones in the region. | `bool` | `false` | no |
 
 ## Outputs

--- a/provider.tf
+++ b/provider.tf
@@ -7,8 +7,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  profile = var.aws_profile
-  region  = var.rsc_exocompute_region
-}

--- a/variables.tf
+++ b/variables.tf
@@ -66,11 +66,6 @@ variable "aws_exocompute_vpc_cidr" {
   description = "VPC CIDR for the AWS account hosting Exocompute."
 }
 
-variable "aws_profile" {
-  description = "AWS profile name."
-  type        = string
-}
-
 variable "aws_exocompute_subnet_private_1_name" {
   description = "Name for the first private subnet that Exocompute will use in the AWS account and region."
   type        = string
@@ -130,11 +125,6 @@ variable "aws_exocompute_vpc_name" {
   description = "VPC name for the AWS account hosting Exocompute."
   type        = string
   default     = "Rubrik Exocompute VPC"
-}
-
-variable "rsc_exocompute_region" {
-  type        = string
-  description = "AWS region for the Exocompute cluster."
 }
 
 variable "use_availability_zones_a_and_b" {


### PR DESCRIPTION
## Overview
This module currently defines its own `provider "aws"` block, which prevents provider inheritance from the root. 

In multi-account setups that use assume-role chains, the submodule ends up using the source role instead of the intended child-account role, causing resources to be applied in the wrong account. 

Passing an `aws_profile` is also suboptimal since profiles are CLI-specific; authentication should be handled at the root provider.

## Rationale

Per Terraform docs:  
> “A module intended to be called by one or more other modules **must not contain any `provider` blocks.**”  
https://developer.hashicorp.com/terraform/language/modules/develop/providers

This module should rely on the root’s provider (and explicit provider passing via `providers = { aws = aws.child }` when needed), not re-declare it.

## Proposed changes

- Remove the internal `provider "aws" { ... }` block  
- Rely on root-level provider inheritance / explicit provider passing  
- Keep `required_providers` for version constraints  

## Benefits

- Correct account targeting with assume-role chains  
- Users can override provider settings from the root  
- Aligns with Terraform best practices  
- Fewer module variables  
